### PR TITLE
Add invitation expiry and clean_invitation mgmt command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,21 @@ Changelog of nens-auth-client
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added Invitation model.
+
+- The authorize view accepts an "invitation" query parameter. If the invitation
+  is valid, a new user will be created. Or, if present, invitation.user will
+  be used to log in.
+
+- Added accept_invitation view.
+
+- Added invitation expiry and a management command "clean_invitations".
+
+- Removed the EmailVerifiedBackend.
+
+- Added SSOMigrationBackend.
+
+- Removed all secrets from the repository to be able to make it public.
 
 
 0.3 (2020-10-20)

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ The complete first-time user flow goes like this:
 
 
 Creating and sending invitations
----------------------------------
+--------------------------------
 
 Invitation objects can be created with and without an associated user. For
 invitations that have no associated user, a user will be created
@@ -174,6 +174,14 @@ Change the invitation email subject as follows::
 
     NENS_AUTH_INVITATION_EMAIL_SUBJECT = "My-custom-subject"  # this is the default
 
+
+Cleaning invitations
+--------------------
+
+Invitation objects need to be cleaned periodically, or else the database table
+will keep growing. Use the management command `clean_invitations` for that, or
+wrap the `nens_auth_client.models.clean_invitations` function in a celery task
+and schedule it every day.
 
 Migrating existing users
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,10 @@ Change the invitation email subject as follows::
 
     NENS_AUTH_INVITATION_EMAIL_SUBJECT = "My-custom-subject"  # this is the default
 
+By default, an invitation is valid for 14 days. Change this as follows::
+
+    NENS_AUTH_INVITATION_EXPIRY_DAYS = 7
+
 
 Cleaning invitations
 --------------------

--- a/nens_auth_client/conf.py
+++ b/nens_auth_client/conf.py
@@ -17,6 +17,7 @@ class NensAuthClientAppConf(AppConf):
     PERMISSION_BACKEND = "nens_auth_client.permissions.DjangoPermissionBackend"
 
     INVITATION_EMAIL_SUBJECT = "Invitation"
+    INVITATION_EXPIRY_DAYS = 14  # change this to change the default expiry
 
     class Meta:
         prefix = "NENS_AUTH"

--- a/nens_auth_client/management/commands/clean_invitations.py
+++ b/nens_auth_client/management/commands/clean_invitations.py
@@ -4,7 +4,7 @@ from nens_auth_client.models import clean_invitations
 
 
 class Command(BaseCommand):
-    help = "Cleans invitations older than n days."
+    help = "Clean (expired) invitations older than n days."
 
     def add_arguments(self, parser):
         parser.add_argument("days", type=int, default=90)
@@ -21,5 +21,5 @@ class Command(BaseCommand):
         if count == 0:
             msg = "No invitations to delete"
         else:
-            msg = "Successfully deleted {} invitations"
+            msg = "Successfully deleted {} invitations".format(count)
         self.stdout.write(self.style.SUCCESS(msg))

--- a/nens_auth_client/management/commands/clean_invitations.py
+++ b/nens_auth_client/management/commands/clean_invitations.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from nens_auth_client.models import clean_invitations
+
+
+class Command(BaseCommand):
+    help = "Cleans invitations older than n days."
+
+    def add_arguments(self, parser):
+        parser.add_argument("days", type=int, default=90)
+
+    def handle(self, *args, **options):
+        try:
+            count = clean_invitations(days=options["days"])
+        except ValueError as e:
+            # a ValueError will occur when options['days'] is invalid
+            # reraise for nice commandline formatting
+            raise CommandError(str(e))
+
+        # Format a success message
+        if count == 0:
+            msg = "No invitations to delete"
+        else:
+            msg = "Successfully deleted {} invitations"
+        self.stdout.write(self.style.SUCCESS(msg))

--- a/nens_auth_client/models.py
+++ b/nens_auth_client/models.py
@@ -120,7 +120,7 @@ class Invitation(models.Model):
     def expires_at(self):
         return self.created_at + timedelta(days=settings.NENS_AUTH_INVITATION_EXPIRY_DAYS)
 
-    def check_acceptable(self):
+    def check_acceptability(self):
         """Checks if this invitation is PENDING and if it has not expired
 
         Raises PermissionDenied if the invitation is not acceptable
@@ -213,7 +213,7 @@ class Invitation(models.Model):
         self.save()
 
 
-def clean_invitations(days=90):
+def clean_invitations(days):
     """Delete invitations that are older than given amount of days.
 
     Args:

--- a/nens_auth_client/models.py
+++ b/nens_auth_client/models.py
@@ -200,7 +200,7 @@ class Invitation(models.Model):
 
 
 def clean_invitations(days=90):
-    """Delete Invitations that are older than given amount of days
+    """Delete invitations that are older than given amount of days.
 
     Args:
       days (int)
@@ -209,7 +209,7 @@ def clean_invitations(days=90):
       the number of Invitations deleted (int)
 
     Note that ``days`` must be >= NENS_AUTH_INVITATION_EXPIRY_DAYS, and
-    preferably significantly larger to be able to be able to inform the user
+    preferably significantly larger to be able to inform the user
     that an Invitation has expired (as opposed to 'not found').
     """
     if days < settings.NENS_AUTH_INVITATION_EXPIRY_DAYS:

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -11,6 +11,7 @@ from django.http.response import HttpResponseNotFound
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.http import is_safe_url
 from django.views.decorators.cache import cache_control
 from urllib.parse import urlencode
@@ -210,9 +211,11 @@ def accept_invitation(request, slug):
     invitation = get_object_or_404(Invitation, slug=slug)
     if invitation.status != Invitation.PENDING:
         return HttpResponseNotFound(
-            "The invitation cannot be accepted because it has "
+            "This invitation cannot be accepted because it has "
             "status '{}'.".format(invitation.get_status_display())
         )
+    if invitation.expires_at > timezone.now():
+        return HttpResponseNotFound("This invitation has expired")
 
     # We need a user - redirect to login view if user is not authenticated
     if not request.user.is_authenticated:

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -122,7 +122,7 @@ def authorize(request):
             )
         except Invitation.DoesNotExist:
             raise PermissionDenied("No invitation matches the given query.")
-        invitation.check_acceptable()  # May raise PermissionDenied
+        invitation.check_acceptability()  # May raise PermissionDenied
         if invitation.user is not None:
             # associate permanently
             user = invitation.user
@@ -206,7 +206,7 @@ def accept_invitation(request, slug):
     invitation = get_object_or_404(Invitation, slug=slug)
 
     try:
-        invitation.check_acceptable()  # May raise PermissionDenied
+        invitation.check_acceptability()  # May raise PermissionDenied
     except PermissionDenied as e:
         return HttpResponseNotFound(str(e))
 

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -214,7 +214,7 @@ def accept_invitation(request, slug):
             "This invitation cannot be accepted because it has "
             "status '{}'.".format(invitation.get_status_display())
         )
-    if invitation.expires_at > timezone.now():
+    if invitation.expires_at < timezone.now():
         return HttpResponseNotFound("This invitation has expired")
 
     # We need a user - redirect to login view if user is not authenticated


### PR DESCRIPTION
Changes:

- If an invitation is older than the setting INVITATION_EXPIRY_DAYS, it cannot be accepted anymore.
- The function / mgmt command `clean_invitations` removes old invitations
- Updated changelog with all PRs since last release