### PR TITLE
Fix error when using authorize with invitation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of nens-auth-client
 0.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed error when using authorize view with "invitation" query parameter.
 
 
 0.4 (2020-12-08)

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -105,6 +105,7 @@ def test_authorize_with_invitation_existing_user(
 
     # check if login was called
     login_m.assert_called_with(request, user)
+    assert user.backend == "nens_auth_client.backends.RemoteUserBackend"
 
     # check if update_user was called
     users_m.update_user.assert_called_with(user, claims)
@@ -143,6 +144,7 @@ def test_authorize_with_invitation_new_user(
 
     # check if login was called
     login_m.assert_called_with(request, user)
+    assert user.backend == "nens_auth_client.backends.RemoteUserBackend"
 
     # check if update_user was called
     users_m.update_user.assert_called_with(user, claims)

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -21,6 +21,9 @@ import django.contrib.auth as django_auth
 LOGIN_REDIRECT_SESSION_KEY = "nens_auth_login_redirect_to"
 INVITATION_KEY = "nens_auth_invitation_slug"
 LOGOUT_REDIRECT_SESSION_KEY = "nens_auth_logout_redirect_to"
+REMOTE_USER_BACKEND_PATH = ".".join(
+    [RemoteUserBackend.__module__, RemoteUserBackend.__name__]
+)
 
 
 def _get_redirect_from_next(request, default):
@@ -131,7 +134,7 @@ def authorize(request):
             # create user and associate permanently
             user = users.create_user(claims)
 
-        user.backend = RemoteUserBackend  # needed for login
+        user.backend = REMOTE_USER_BACKEND_PATH  # needed for login
 
     # No user, no login
     if user is None:


### PR DESCRIPTION
It appears that django's `contrib.auth.login` function expects `user.backend` to be set to the import path of the Authentication Backend, and not to the class itself...