### PR TITLE
Override admin and DRF login views

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Achieve this as follows (in urls.py)::
 The override always goes before the corresponding include.
 Note that if you use a non-standard path it should be given as argument to
 the override, e.g. ``override_admin_auth("my-custom-admin-path")``.
+The path admin/local-login is added for emergency access.
 
 If not done already for your project, set up a working email backend and a
 sender ('from') email address::

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,27 @@ You must register the absolute ``authorize`` and ``logout`` URIs in AWS Cognito.
 If the site runs on multiple domains, they all have to be registered. Wildcards
 are not possible because of security reasons.
 
+The admin and djangorestframework login / logout views should be overridden.
+Otherwise these views still try to authenticate in the local (Django) database.
+Achieve this as follows (in urls.py)::
+
+    from nens_auth_client.urls import override_admin_auth
+    from nens_auth_client.urls import override_rest_framework_auth
+
+    urlpatterns = [
+        ...
+        *override_admin_auth(),
+        url(r"^admin/", admin.site.urls),  # is probably already there
+        ...
+        *override_rest_framework_auth(),  # only if you use rest_framework
+        url(r"^api-auth/", include("rest_framework.urls"), namespace="rest_framework"),
+        ...
+    ]
+
+The override always goes before the corresponding include.
+Note that if you use a non-standard path it should be given as argument to
+the override, e.g. ``override_admin_auth("my-custom-admin-path")``.
+
 If not done already for your project, set up a working email backend and a
 sender ('from') email address::
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Achieve this as follows (in urls.py)::
 The override always goes before the corresponding include.
 Note that if you use a non-standard path it should be given as argument to
 the override, e.g. ``override_admin_auth("my-custom-admin-path")``.
-The path admin/local-login is added for emergency access.
+The path admin/local-login is added (by the override) for emergency access.
 
 If not done already for your project, set up a working email backend and a
 sender ('from') email address::

--- a/nens_auth_client/urls.py
+++ b/nens_auth_client/urls.py
@@ -25,6 +25,33 @@ try:
 except ImportError:  # Django 1.11 compatibility
     from django.conf.urls import url as re_path
 
+
+def override_admin_auth(admin_path="admin"):
+    """This should be included in the urlpatterns of the root site before
+    the admin urls are included.
+
+    The login and logout paths are overriden. An admin/local_login/ path is
+    added for backdoor access with local accounts.
+    """
+    return [
+        url("^{}/login/".format(admin_path), views.login, name="admin-login-override"),
+        url("^{}/logout/".format(admin_path), views.logout, name="admin-logout-override"),
+        url("^{}/local_login/".format(admin_path), admin.site.login, name="admin-local-login")
+    ]
+
+
+def override_rest_framework_auth(drf_path="api-auth"):
+    """This should be included in the urlpatterns of the root site before
+    the rest_framework urls are included.
+
+    The login and logout paths are overriden.
+    """
+    return [
+        url("^{}/login/".format(drf_path), login, name="drf-login-override"),
+        url("^{}/logout/".format(drf_path), logout, name="drf-logout-override"),
+    ]
+
+
 app_name = NensAuthClientConfig.name
 
 urlpatterns = [

--- a/nens_auth_client/urls.py
+++ b/nens_auth_client/urls.py
@@ -27,7 +27,9 @@ except ImportError:  # Django 1.11 compatibility
 
 
 def override_admin_auth(admin_path="admin"):
-    """This should be included in the urlpatterns of the root site before
+    """Return login/logout url paths to enable cognito-based authentication.
+    
+    This should be included in the urlpatterns of the root site before
     the admin urls are included.
 
     The login and logout paths are overriden. An admin/local-login/ path is
@@ -41,7 +43,9 @@ def override_admin_auth(admin_path="admin"):
 
 
 def override_rest_framework_auth(drf_path="api-auth"):
-    """This should be included in the urlpatterns of the root site before
+    """Return login/logout url paths to enable cognito-based authentication.
+    
+    This should be included in the urlpatterns of the root site before
     the rest_framework urls are included.
 
     The login and logout paths are overriden.

--- a/nens_auth_client/urls.py
+++ b/nens_auth_client/urls.py
@@ -30,13 +30,13 @@ def override_admin_auth(admin_path="admin"):
     """This should be included in the urlpatterns of the root site before
     the admin urls are included.
 
-    The login and logout paths are overriden. An admin/local_login/ path is
+    The login and logout paths are overriden. An admin/local-login/ path is
     added for backdoor access with local accounts.
     """
     return [
-        url("^{}/login/".format(admin_path), views.login, name="admin-login-override"),
-        url("^{}/logout/".format(admin_path), views.logout, name="admin-logout-override"),
-        url("^{}/local_login/".format(admin_path), admin.site.login, name="admin-local-login")
+        re_path("^{}/login/".format(admin_path), views.login, name="admin-login-override"),
+        re_path("^{}/logout/".format(admin_path), views.logout, name="admin-logout-override"),
+        re_path("^{}/local-login/".format(admin_path), admin.site.login, name="admin-local-login")
     ]
 
 
@@ -47,8 +47,8 @@ def override_rest_framework_auth(drf_path="api-auth"):
     The login and logout paths are overriden.
     """
     return [
-        url("^{}/login/".format(drf_path), login, name="drf-login-override"),
-        url("^{}/logout/".format(drf_path), logout, name="drf-logout-override"),
+        re_path("^{}/login/".format(drf_path), views.login, name="drf-login-override"),
+        re_path("^{}/logout/".format(drf_path), views.logout, name="drf-logout-override"),
     ]
 
 
@@ -66,4 +66,7 @@ urlpatterns = [
 ]
 
 if settings.NENS_AUTH_STANDALONE:
-    urlpatterns += [re_path("^admin/", admin.site.urls)]
+    urlpatterns += [
+        *override_admin_auth(),
+        re_path("^admin/", admin.site.urls)
+    ]


### PR DESCRIPTION
The admin and DRF views (like demo.lizard.net/admin or demo.lizard.net/api/v3/ , topright corner) do a local login.

This will not be possible anymore in the future. So these should redirect in some way to AWS Cognito.

I first tried to override the templates of the admin and DRF sites, but this becomes very ugly. I am worried about future version compatibilities if I do it like that. So I ended up with this option: including the exact same url path right before the 'normal' include. This works nicely. I also expect this to be stable in the future.