### PR TITLE
Fix request.session 'in' operator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of nens-auth-client
 0.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed faulty error message if user does not exist.
 
 
 0.6 (2021-01-11)

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -117,7 +117,7 @@ def authorize(request):
     user = django_auth.authenticate(request, claims=claims)
 
     # If nothing was found: only a valid invitation warrants a new user association
-    if user is None and INVITATION_KEY in request.session:
+    if user is None and request.session.get(INVITATION_KEY):
         try:
             invitation = Invitation.objects.select_related("user").get(
                 slug=request.session[INVITATION_KEY]


### PR DESCRIPTION
Apparently any key is 'present' in the session. `"some-string" in request.session` always yields `True`. Only most keys will result in `None`

This resulted in a wrong error message NENS_AUTH_ERROR_INVITATION_DOES_NOT_EXIST instead of NENS_AUTH_ERROR_USER_DOES_NOT_EXIST.