### PR TITLE
Fix authorize if there is not redirect in the session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changelog of nens-auth-client
 
 - Fixed faulty error message if user does not exist.
 
+- Fixed authorize if there is no redirect in the session.
+
+- Stop storing the default redirect urls in the session. This prevents creating
+  a session in the login or logout flows if no 'next' url param is used.
+
 
 0.6 (2021-01-11)
 ----------------

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -88,11 +88,14 @@ def test_authorize_no_redirect_in_session(
     id_token, claims = id_token_generator(testclaim="bar")
     user = User(username="testuser")
     request = auth_req_generator(id_token, user=user)
+
+    # delete the redirect from the session
     del request.session[views.LOGIN_REDIRECT_SESSION_KEY]
 
     response = views.authorize(request)
 
-    assert response.status_code == 302  # 302 redirect to success url: all checks passed
+    # successful authorize should redirect to the default success url:
+    assert response.status_code == 302
     assert response.url == settings.NENS_AUTH_DEFAULT_SUCCESS_URL
 
 

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -82,6 +82,20 @@ def test_authorize_no_user(id_token_generator, auth_req_generator, users_m, logi
     assert not users_m.update_user.called
 
 
+def test_authorize_no_redirect_in_session(
+    id_token_generator, auth_req_generator, users_m, login_m, invitation_getter
+):
+    id_token, claims = id_token_generator(testclaim="bar")
+    user = User(username="testuser")
+    request = auth_req_generator(id_token, user=user)
+    del request.session[views.LOGIN_REDIRECT_SESSION_KEY]
+
+    response = views.authorize(request)
+
+    assert response.status_code == 302  # 302 redirect to success url: all checks passed
+    assert response.url == settings.NENS_AUTH_DEFAULT_SUCCESS_URL
+
+
 def test_authorize_with_invitation_existing_user(
     id_token_generator, auth_req_generator, users_m, login_m, invitation_getter
 ):

--- a/nens_auth_client/tests/test_login_view.py
+++ b/nens_auth_client/tests/test_login_view.py
@@ -40,9 +40,35 @@ def test_login_when_already_logged_in(rf):
     request.user = User()
     response = views.login(request)
 
-    # login generated a redirect to the (absolutized) 'next' parameter
+    # login generated a redirect to the 'next' parameter
     assert response.status_code == 302
     assert response.url == "/a"
+
+    # login did not alter the session
+    assert request.session == {}
+
+
+def test_login_no_next_url(rf):
+    # The login view redirects to DEFAULT_SUCCESS_URL if already logged in
+    request = rf.get("http://testserver/login/")
+    request.session = {}
+    request.user = User()
+    views.login(request)
+
+    # login did not alter the session
+    assert request.session == {}
+
+
+def test_login_no_next_url_already_logged_in(rf):
+    # The login view redirects to DEFAULT_SUCCESS_URL if already logged in
+    request = rf.get("http://testserver/login/")
+    request.session = {}
+    request.user = User()
+    response = views.login(request)
+
+    # login generated a redirect to the default redirect setting
+    assert response.status_code == 302
+    assert response.url == settings.NENS_AUTH_DEFAULT_SUCCESS_URL
 
 
 @pytest.mark.parametrize(

--- a/nens_auth_client/tests/test_login_view.py
+++ b/nens_auth_client/tests/test_login_view.py
@@ -44,7 +44,7 @@ def test_login_when_already_logged_in(rf):
     assert response.status_code == 302
     assert response.url == "/a"
 
-    # login did not alter the session
+    # login did not add anything to the session
     assert request.session == {}
 
 
@@ -55,8 +55,8 @@ def test_login_no_next_url(rf):
     request.user = User()
     views.login(request)
 
-    # login did not alter the session
-    assert request.session == {}
+    # login did not add a redirect url to the session
+    assert views.LOGIN_REDIRECT_SESSION_KEY not in request.session
 
 
 def test_login_no_next_url_already_logged_in(rf):
@@ -74,13 +74,13 @@ def test_login_no_next_url_already_logged_in(rf):
 @pytest.mark.parametrize(
     "url,expected",
     [
-        ("login/", "/x"),
+        ("login/", None),
         ("login/?next=/a", "/a"),
         ("login/?next=https://testserver/a", "https://testserver/a"),
-        ("login/?next=https://testserver2/a", "/x"),  # different domain
-        ("login/?next=http://testserver/a", "/x"),  # https to http
+        ("login/?next=https://testserver2/a", None),  # different domain
+        ("login/?next=http://testserver/a", None),  # https to http
     ],
 )
 def test_get_redirect_from_next(rf, url, expected):
     request = rf.get(url, secure=True)
-    assert views._get_redirect_from_next(request, default="/x") == expected
+    assert views._get_redirect_from_next(request) == expected

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -34,7 +34,7 @@ def test_logout(rf, mocker, openid_configuration):
 def test_logout_as_callback(rf, mocker):
     django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
 
-    request = rf.get("http://testserver/logout/?next=/a")
+    request = rf.get("http://testserver/logout/")
     request.session = {views.LOGOUT_REDIRECT_SESSION_KEY: "/b"}
     request.user = AnonymousUser()  # user is not logged in anymore
     response = views.logout(request)
@@ -65,3 +65,37 @@ def test_logout_not_logged_in(rf, mocker):
 
     # django logout was not called
     assert not django_logout.called
+
+
+def test_logout_no_next_url(rf, mocker, openid_configuration):
+    mocker.patch("nens_auth_client.views.django_auth.logout")
+
+    request = rf.get("http://testserver/logout/")
+    request.session = {}
+    request.user = User()  # user is logged in initially
+    views.logout(request)
+
+    # there is no 'next' param stored in the session
+    assert request.session == {}
+
+
+def test_logout_as_callback_no_session(rf, mocker, openid_configuration):
+    request = rf.get("http://testserver/logout/")
+    request.session = {}
+    request.user = AnonymousUser()  # user is not logged in anymore
+    response = views.logout(request)
+
+    # logout generated a redirect to the url stored in the session
+    assert response.status_code == 302
+    assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL
+
+
+def test_logout_not_logged_in_no_next_url(rf, mocker):
+    request = rf.get("http://testserver/logout/")
+    request.session = {}
+    request.user = AnonymousUser()  # user is not logged in initially
+    response = views.logout(request)
+
+    # logout generated a redirect to the 'next' URL
+    assert response.status_code == 302
+    assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -76,10 +76,10 @@ def test_logout_no_next_url(rf, mocker, openid_configuration):
     views.logout(request)
 
     # there is no redirect url stored in the session
-    assert request.session == {}
+    assert views.LOGOUT_REDIRECT_SESSION_KEY not in request.session
 
 
-def test_logout_as_callback_no_session(rf, mocker, openid_configuration):
+def test_logout_as_callback_empty_session(rf, mocker, openid_configuration):
     request = rf.get("http://testserver/logout/")
     request.session = {}
     request.user = AnonymousUser()  # user is not logged in anymore

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -34,7 +34,7 @@ def test_logout(rf, mocker, openid_configuration):
 def test_logout_as_callback(rf, mocker):
     django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
 
-    request = rf.get("http://testserver/logout/")
+    request = rf.get("http://testserver/logout/?next=/a")
     request.session = {views.LOGOUT_REDIRECT_SESSION_KEY: "/b"}
     request.user = AnonymousUser()  # user is not logged in anymore
     response = views.logout(request)
@@ -75,7 +75,7 @@ def test_logout_no_next_url(rf, mocker, openid_configuration):
     request.user = User()  # user is logged in initially
     views.logout(request)
 
-    # there is no 'next' param stored in the session
+    # there is no redirect url stored in the session
     assert request.session == {}
 
 
@@ -85,7 +85,7 @@ def test_logout_as_callback_no_session(rf, mocker, openid_configuration):
     request.user = AnonymousUser()  # user is not logged in anymore
     response = views.logout(request)
 
-    # logout generated a redirect to the url stored in the session
+    # logout generated a redirect to the default logout url
     assert response.status_code == 302
     assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL
 
@@ -96,6 +96,6 @@ def test_logout_not_logged_in_no_next_url(rf, mocker):
     request.user = AnonymousUser()  # user is not logged in initially
     response = views.logout(request)
 
-    # logout generated a redirect to the 'next' URL
+    # logout generated a redirect to the default logout url
     assert response.status_code == 302
     assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -26,9 +26,9 @@ REMOTE_USER_BACKEND_PATH = ".".join(
 
 
 def _get_redirect_from_next(request):
-    """Return redirect url from the "next" parameter in the url
+    """Return redirect url from the "next" parameter in the url.
 
-    Returns the default if there is no "next" parameter or if it is unsafe.
+    Returns None if there is no "next" parameter or if it is unsafe.
     """
     if REDIRECT_FIELD_NAME in request.GET:
         redirect_to = request.GET[REDIRECT_FIELD_NAME]


### PR DESCRIPTION
I took the opportunity to think about what keys are actually necessary in the session:

- if a user did not provide a 'next' url, we do not need to store the redirect (because we use the default anyway if the redirect is not present in the session)
- an invitation key in the session should be cleaned up after usage (because an invitation can be accepted only once anyway)
- I am not sure about cleaning up the other session keys (redirect url, state, nonce). Should the /authorize call be repeatable? I can't find anything in the OIDC or OAuth2 specs about this. So I'll leave it now.