### PR TITLE
Pick usernames for new users more intelligently

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog of nens-auth-client
 0.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Pick the email as username for newly registered users coming from an external
+  identity provider.
+
+- Handle username uniqueness constraint by appending 4 random characters after
+  the username when necessary.
 
 
 0.7 (2021-01-13)


### PR DESCRIPTION
When testing I encountered an issue with creating new users from external identity providers. They get a username like "google_51234125123516521", which I find quite ugly when displayed in the top right corner in e.g. the Django REST Framework.

There is no real meaning to our local usernames anymore (users can't user them to log in locally, as they have no password) so we basically have a free choice what to do here. I opted for filling the username with the email for externally signed up users.

Then a second issue arose: what if that username is already taken? I don't want IntegrityErrors from a field that doesn't have a real meaning anymore. So I append 4 random characters to the username if that occurs.

Now it should *always* work and give a nicely formatted username in almost all cases.