### PR TITLE
Do not require presence of email claim

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changelog of nens-auth-client
 - Added a check if the user's and invitation's email match. It does not matter
   whether the user's email was verified.
 
+- Never require presence of "email" claim in the ID token.
+
 
 0.7 (2021-01-13)
 ----------------

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -133,7 +133,7 @@ def authorize(request):
         except Invitation.DoesNotExist:
             raise PermissionDenied(settings.NENS_AUTH_ERROR_INVITATION_DOES_NOT_EXIST)
         # May raise PermissionDenied:
-        invitation.check_acceptability(email=claims["email"])
+        invitation.check_acceptability(email=claims.get("email") or None)
         if invitation.user is not None:
             # associate permanently
             user = invitation.user
@@ -229,6 +229,4 @@ def accept_invitation(request, slug):
     invitation.check_acceptability(email=request.user.email or None)
     invitation.accept(request.user)
     success_url = _get_redirect_from_next(request)
-    return HttpResponseRedirect(
-        success_url or settings.NENS_AUTH_DEFAULT_SUCCESS_URL
-    )
+    return HttpResponseRedirect(success_url or settings.NENS_AUTH_DEFAULT_SUCCESS_URL)


### PR DESCRIPTION
I encountered a case in which "email" was not existing. This prevents 500 errors in that case.