### PR TITLE
Always redirect to AWS after logout & enable logout-login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Changelog of nens-auth-client
   after remote logout: for that /logout-success/ is introduced. This so that
   users can always logout, also when local login failed.
 
+- Added a logout and then login functionality. This can be used by calling
+  /login?force_logout=true.
+
 
 0.7 (2021-01-13)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Changelog of nens-auth-client
 - Added a check if the user's and invitation's email match. It does not matter
   whether the user's email was verified.
 
+- Split the logout view in two. It is not used anymore as the callback url
+  after remote logout: for that /logout-success/ is introduced. This so that
+  users can always logout, also when local login failed.
+
 
 0.7 (2021-01-13)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,8 @@ Include the ``nens-auth-client`` urls in your application's urls.py::
         ...
     ]
 
-You must register the absolute ``authorize`` and ``logout`` URIs in AWS Cognito.
+You must register the absolute ``authorize`` and ``logout-success`` URIs in
+AWS Cognito.
 If the site runs on multiple domains, they all have to be registered. Wildcards
 are not possible because of security reasons.
 
@@ -110,7 +111,7 @@ The logout flow follows a similar flow:
 1. The user accesses the "logout" view (optionally with a ``next`` query parameter).
 2. The user is logged out locally and is redirected to the Authorization Server's logout view.
 3. The Authorization Server logs the user out.
-4. The user is redirected to the "logout" view.
+4. The user is redirected to the "logout-success" view.
 5. The user is redirected to the 'next' URL provided in step 1.
 
 Optionally set defaults for the redirects after successful login/logout::

--- a/nens_auth_client/tests/test_login_view.py
+++ b/nens_auth_client/tests/test_login_view.py
@@ -84,3 +84,35 @@ def test_login_no_next_url_already_logged_in(rf):
 def test_get_redirect_from_next(rf, url, expected):
     request = rf.get(url, secure=True)
     assert views._get_redirect_from_next(request) == expected
+
+
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_login_with_forced_logout(rf, openid_configuration, mocker, logged_in):
+    django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
+
+    request = rf.get("http://testserver/login/?next=/a&logout=true")
+    request.session = {}
+    request.user = User() if logged_in else AnonymousUser()
+    response = views.login(request)
+
+    assert django_logout.called
+
+    # login generated a redirect to the LOGOUT URL
+    assert response.status_code == 302
+    url = urlparse(response.url)
+    assert url[:3] == ("https", "authserver", "/logout")
+
+    # The query params are conform OpenID Connect spec
+    # https://tools.ietf.org/html/rfc6749#section-4.1.1
+    # https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+    qs = parse_qs(url.query)
+    assert qs["response_type"] == ["code"]
+    assert qs["client_id"] == [settings.NENS_AUTH_CLIENT_ID]
+    assert qs["redirect_uri"] == ["http://testserver/authorize/"]
+    assert qs["scope"] == [" ".join(settings.NENS_AUTH_SCOPE)]
+    assert qs["state"] == [request.session["_cognito_authlib_state_"]]
+    assert qs["nonce"] == [request.session["_cognito_authlib_nonce_"]]
+    assert request.session[views.LOGIN_REDIRECT_SESSION_KEY] == "/a"
+
+    # check if Cache-Control header is set to "no-store"
+    assert response._headers["cache-control"] == ("Cache-Control", "no-store")

--- a/nens_auth_client/tests/test_login_view.py
+++ b/nens_auth_client/tests/test_login_view.py
@@ -90,7 +90,7 @@ def test_get_redirect_from_next(rf, url, expected):
 def test_login_with_forced_logout(rf, openid_configuration, mocker, logged_in):
     django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
 
-    request = rf.get("http://testserver/login/?next=/a&logout=true")
+    request = rf.get("http://testserver/login/?next=/a&force_logout=true")
     request.session = {}
     request.user = User() if logged_in else AnonymousUser()
     response = views.login(request)

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 from nens_auth_client import views
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import PermissionDenied
 
 import pytest
 
@@ -72,11 +73,10 @@ def test_logout_success_empty_session(rf, mocker, openid_configuration):
 
 def test_logout_success_logged_in(rf, mocker):
     # This should only be possible if the user typed in this URL himself.
+    # Give PermissionDenied.
     request = rf.get("http://testserver/logout-success/")
     request.session = {}
     request.user = User()  # user is logged in
-    response = views.logout_success(request)
 
-    # logout generated a redirect to the default logout url
-    assert response.status_code == 302
-    assert response.url == "/logout/"
+    with pytest.raises(PermissionDenied):
+        views.logout_success(request)

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -4,13 +4,16 @@ from nens_auth_client import views
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 
+import pytest
 
-def test_logout(rf, mocker, openid_configuration):
+
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_logout(rf, mocker, openid_configuration, logged_in):
     django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
 
     request = rf.get("http://testserver/logout/?next=/a")
     request.session = {}
-    request.user = User()  # user is logged in initially
+    request.user = User() if logged_in else AnonymousUser()
     response = views.logout(request)
 
     # login generated a redirect to the LOGOUT_URL
@@ -19,7 +22,7 @@ def test_logout(rf, mocker, openid_configuration):
     assert url[:3] == ("https", "authserver", "/logout")
     qs = parse_qs(url.query)
     assert qs["client_id"] == [settings.NENS_AUTH_CLIENT_ID]
-    assert qs["logout_uri"] == ["http://testserver/logout/"]
+    assert qs["logout_uri"] == ["http://testserver/logout-success/"]
 
     # django logout was called
     assert django_logout.called
@@ -31,71 +34,49 @@ def test_logout(rf, mocker, openid_configuration):
     assert response._headers["cache-control"] == ("Cache-Control", "no-store")
 
 
-def test_logout_as_callback(rf, mocker):
-    django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
-
-    request = rf.get("http://testserver/logout/?next=/a")
-    request.session = {views.LOGOUT_REDIRECT_SESSION_KEY: "/b"}
-    request.user = AnonymousUser()  # user is not logged in anymore
-    response = views.logout(request)
-
-    # logout generated a redirect to the url stored in the session
-    assert response.status_code == 302
-    assert response.url == "/b"
-
-    # django logout was not called
-    assert not django_logout.called
-
-    # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
-
-
-def test_logout_not_logged_in(rf, mocker):
-    # A user logs out without being logged in
-    django_logout = mocker.patch("nens_auth_client.views.django_auth.logout")
-
-    request = rf.get("http://testserver/logout/?next=/a")
-    request.session = {}
-    request.user = AnonymousUser()  # user is not logged in initially
-    response = views.logout(request)
-
-    # logout generated a redirect to the 'next' URL
-    assert response.status_code == 302
-    assert response.url == "/a"
-
-    # django logout was not called
-    assert not django_logout.called
-
-
 def test_logout_no_next_url(rf, mocker, openid_configuration):
     mocker.patch("nens_auth_client.views.django_auth.logout")
 
     request = rf.get("http://testserver/logout/")
     request.session = {}
-    request.user = User()  # user is logged in initially
     views.logout(request)
 
     # there is no redirect url stored in the session
     assert views.LOGOUT_REDIRECT_SESSION_KEY not in request.session
 
 
-def test_logout_as_callback_empty_session(rf, mocker, openid_configuration):
-    request = rf.get("http://testserver/logout/")
+def test_logout_success(rf, mocker):
+    request = rf.get("http://testserver/logout-success/")
+    request.session = {views.LOGOUT_REDIRECT_SESSION_KEY: "/b"}
+    request.user = AnonymousUser()  # user is not logged in anymore
+    response = views.logout_success(request)
+
+    # logout generated a redirect to the url stored in the session
+    assert response.status_code == 302
+    assert response.url == "/b"
+
+    # check if Cache-Control header is set to "no-store"
+    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+
+
+def test_logout_success_empty_session(rf, mocker, openid_configuration):
+    request = rf.get("http://testserver/logout-success/")
     request.session = {}
     request.user = AnonymousUser()  # user is not logged in anymore
-    response = views.logout(request)
+    response = views.logout_success(request)
 
     # logout generated a redirect to the default logout url
     assert response.status_code == 302
     assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL
 
 
-def test_logout_not_logged_in_no_next_url(rf, mocker):
-    request = rf.get("http://testserver/logout/")
+def test_logout_success_logged_in(rf, mocker):
+    # This should only be possible if the user typed in this URL himself.
+    request = rf.get("http://testserver/logout-success/")
     request.session = {}
-    request.user = AnonymousUser()  # user is not logged in initially
-    response = views.logout(request)
+    request.user = User()  # user is logged in
+    response = views.logout_success(request)
 
     # logout generated a redirect to the default logout url
     assert response.status_code == 302
-    assert response.url == settings.NENS_AUTH_DEFAULT_LOGOUT_URL
+    assert response.url == "/logout/"

--- a/nens_auth_client/urls.py
+++ b/nens_auth_client/urls.py
@@ -62,7 +62,7 @@ urlpatterns = [
     re_path("^authorize/$", views.authorize, name="authorize"),
     re_path("^login/$", views.login, name="login"),
     re_path("^logout/$", views.logout, name="logout"),
-    re_path("^logout-success/$", views.logout, name="logout-success"),
+    re_path("^logout-success/$", views.logout_success, name="logout-success"),
     re_path(
         r"^invitations/(?P<slug>\w+)/accept/",
         views.accept_invitation,

--- a/nens_auth_client/urls.py
+++ b/nens_auth_client/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
     re_path("^authorize/$", views.authorize, name="authorize"),
     re_path("^login/$", views.login, name="login"),
     re_path("^logout/$", views.logout, name="logout"),
+    re_path("^logout-success/$", views.logout, name="logout-success"),
     re_path(
         r"^invitations/(?P<slug>\w+)/accept/",
         views.accept_invitation,

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -214,7 +214,7 @@ def logout_success(request):
       that is stored in the session (or default logout url if unavailable).
     - if user is logged in locally: HTTP 302 Redirect to the logout view
     """
-    # If a user is still authenticated: redirect to logout view.
+    # If a user is still authenticated: this should not happen. Return 403.
     if request.user.is_authenticated:
         raise PermissionDenied("Logout failure")
 

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -52,7 +52,7 @@ def login(request):
         settings.NENS_AUTH_DEFAULT_SUCCESS_URL
       invitation: an optional Invitation id. On authorization success, a user will be
         created and permissions from the Invitation are applied.
-      logout: if "true", force local and remote logout
+      force_logout: if "true", force local and remote logout
 
     Response:
       HTTP 302 Redirect to AWS Cognito (according to the OpenID Connect standard)
@@ -68,7 +68,7 @@ def login(request):
     success_url = _get_redirect_from_next(request)
 
     # Whether to force logout or not
-    force_logout = request.GET.get("logout") == "true"
+    force_logout = request.GET.get("force_logout") == "true"
     if force_logout:
         django_auth.logout(request)
     elif request.user.is_authenticated:


### PR DESCRIPTION
This adds two new things:

- /logout -> AWS Cognito LOGOUT -> /logout-success
- /login?force_logout=true -> AWS Cognito LOGOUT -> AWS Cognito LOGIN -> /authorize

Will need a change in the callback logout url in tf-cognito.  I did it now manually in the nens_auth_client_local client.