### PR TITLE
Extend email template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of nens-auth-client
 0.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added option to specify to which organisation and corresponding
+  roles a user is invited to in invitation email. (Lizard #5041)
 
 
 0.10 (2021-02-23)

--- a/nens_auth_client/models.py
+++ b/nens_auth_client/models.py
@@ -208,12 +208,12 @@ class Invitation(models.Model):
         return request.build_absolute_uri(relative_url)
 
     def send_email(
-            self,
-            request,
-            context=None,
-            send_email_options=None,
-            organisation_and_roles=None,
-        ):
+        self,
+        request,
+        context=None,
+        send_email_options=None,
+        organisation_and_roles=None,
+    ):
         """Send the invitation email.
 
         The email address is taken from invitation.email.
@@ -237,7 +237,7 @@ class Invitation(models.Model):
           send_email_options (dict): an optional dict for custom send_email
             arguments. see django's docs on send_email.
           organisation_and_roles (dict): optional dict to specify a list of
-            organisations and corresponing roles a user is invited to. 
+            organisations and corresponing roles a user is invited to.
             format: {"org_1_name": ["role1", "role2"]}
         """
         assert self.status == self.PENDING, "The invite must be PENDING"

--- a/nens_auth_client/models.py
+++ b/nens_auth_client/models.py
@@ -207,7 +207,13 @@ class Invitation(models.Model):
         )
         return request.build_absolute_uri(relative_url)
 
-    def send_email(self, request, context=None, send_email_options=None):
+    def send_email(
+            self,
+            request,
+            context=None,
+            send_email_options=None,
+            organisation_and_roles=None,
+        ):
         """Send the invitation email.
 
         The email address is taken from invitation.email.
@@ -230,13 +236,23 @@ class Invitation(models.Model):
             the domain name from
           send_email_options (dict): an optional dict for custom send_email
             arguments. see django's docs on send_email.
+          organisation_and_roles (dict): optional dict to specify a list of
+            organisations and corresponing roles a user is invited to. 
+            format: {"org_1_name": ["role1", "role2"]}
         """
         assert self.status == self.PENDING, "The invite must be PENDING"
+
+        if organisation_and_roles:
+            organisation_and_roles = [
+                f"- {organisation}, role(s): {','.join(role)}"
+                for organisation, role in organisation_and_roles.items()
+            ]
 
         context = {
             "invitation": self,
             "accept_url": self.get_accept_url(request),
             "host": request.get_host(),
+            "organisation_and_roles": organisation_and_roles,
             **(context or {}),
         }
 

--- a/nens_auth_client/models.py
+++ b/nens_auth_client/models.py
@@ -244,7 +244,7 @@ class Invitation(models.Model):
 
         if organisation_and_roles:
             organisation_and_roles = [
-                f"- {organisation}, role(s): {','.join(role)}"
+                "- {}, role(s): {}".format(organisation, ','.join(role))
                 for organisation, role in organisation_and_roles.items()
             ]
 

--- a/nens_auth_client/templates/nens_auth_client/invitation.html
+++ b/nens_auth_client/templates/nens_auth_client/invitation.html
@@ -1,5 +1,14 @@
 <p>Dear user,</p>
-<p>This is an invitation for a user account at {{ host }}.<br />Use the following link to accept:</p>
+<p>This is an invitation for a user account at {{ host }}.</p>
+{% if organisation_and_roles %}
+<p>You are invited for the following organisation(s):</p>
+{% for line in organisation_and_roles %}
+    <p>{{ line }}</p>
+{% endfor %}
+{% endif %}
+</p>
+</br>
+<p>Use the following link to accept:</p>
 <p><a href="{{ accept_url }}">{{ accept_url }}</a></p>
 <p>The above link will first redirect to a page where you can sign in with a corporate ID or a Nelen &amp; Schuurmans account. If you do not have an account in any of the options listed, choose "Sign up".</p>
 <p>For questions, please contact servicedesk@nelen-schuurmans.nl.</p>

--- a/nens_auth_client/templates/nens_auth_client/invitation.txt
+++ b/nens_auth_client/templates/nens_auth_client/invitation.txt
@@ -1,6 +1,12 @@
 Dear user,
 
 This is an invitation for a user account at {{ host }}.
+{% if organisation_and_roles %}
+You are invited for the following organisation(s):
+{% for line in organisation_and_roles %}
+    {{ line }}
+{% endfor %}
+{% endif %}
 Use the following link to accept:
 
 {{ accept_url }}

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -57,8 +57,10 @@ def test_authorize(
     assert qs["state"] == ["state"]
 
     # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
-
+    if hasattr(response, "_headers"):
+        assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    elif hasattr(response, "headers"):
+        assert response.headers["cache-control"] == "no-store"
     # check if login was called
     login_m.assert_called_with(request, user)
 

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -61,6 +61,9 @@ def test_authorize(
         assert response._headers["cache-control"] == ("Cache-Control", "no-store")
     elif hasattr(response, "headers"):
         assert response.headers["cache-control"] == "no-store"
+    else:
+        assert False
+
     # check if login was called
     login_m.assert_called_with(request, user)
 

--- a/nens_auth_client/tests/test_invitation_model.py
+++ b/nens_auth_client/tests/test_invitation_model.py
@@ -129,7 +129,7 @@ def test_send_email_multiple_orgs(rf, invitation, m_send_email, settings):
         organisation_and_roles={"foo": ["bar"], "fizz": ["buzz, bozz"]}
     )
 
-    url = invitation.get_accept_url(request)
+    invitation.get_accept_url(request)
     send_email_kwargs = m_send_email.call_args[1]
     assert "- foo, role(s): bar" in send_email_kwargs["message"]
     assert "- fizz, role(s): buzz, bozz" in send_email_kwargs["message"]

--- a/nens_auth_client/tests/test_invitation_model.py
+++ b/nens_auth_client/tests/test_invitation_model.py
@@ -114,7 +114,10 @@ def test_send_email(rf, invitation, m_send_email, settings):
     assert send_email_kwargs["foo"] == "bar"
 
     assert invitation.email_sent_at is not None
-    assert "- foo, role(s): bar" not in send_email_kwargs["message"]
+    assert (
+        "You are invited for the following organisation(s)"
+        not in send_email_kwargs["message"]
+    )
 
 
 def test_send_email_multiple_orgs(rf, invitation, m_send_email, settings):

--- a/nens_auth_client/tests/test_login_view.py
+++ b/nens_auth_client/tests/test_login_view.py
@@ -30,7 +30,12 @@ def test_login(rf, openid_configuration):
     assert request.session[views.LOGIN_REDIRECT_SESSION_KEY] == "/a"
 
     # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    if hasattr(response, "_headers"):
+        assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    elif hasattr(response, "headers"):
+        assert response.headers["cache-control"] == "no-store"
+    else:
+        assert False
 
 
 def test_login_when_already_logged_in(rf):
@@ -115,4 +120,9 @@ def test_login_with_forced_logout(rf, openid_configuration, mocker, logged_in):
     assert request.session[views.LOGIN_REDIRECT_SESSION_KEY] == "/a"
 
     # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    if hasattr(response, "_headers"):
+        assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    elif hasattr(response, "headers"):
+        assert response.headers["cache-control"] == "no-store"
+    else:
+        assert False

--- a/nens_auth_client/tests/test_logout_view.py
+++ b/nens_auth_client/tests/test_logout_view.py
@@ -32,7 +32,12 @@ def test_logout(rf, mocker, openid_configuration, logged_in):
     assert request.session[views.LOGOUT_REDIRECT_SESSION_KEY] == "/a"
 
     # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    if hasattr(response, "_headers"):
+        assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    elif hasattr(response, "headers"):
+        assert response.headers["cache-control"] == "no-store"
+    else:
+        assert False
 
 
 def test_logout_no_next_url(rf, mocker, openid_configuration):
@@ -57,7 +62,12 @@ def test_logout_success(rf, mocker):
     assert response.url == "/b"
 
     # check if Cache-Control header is set to "no-store"
-    assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    if hasattr(response, "_headers"):
+        assert response._headers["cache-control"] == ("Cache-Control", "no-store")
+    elif hasattr(response, "headers"):
+        assert response.headers["cache-control"] == "no-store"
+    else:
+        assert False
 
 
 def test_logout_success_empty_session(rf, mocker, openid_configuration):


### PR DESCRIPTION
For the improved Lizard invitations endpoint we want to be able to invite a user to multiple organisations. The current email template is not descriptive enough in terms of specifying which organisations and roles this invitation belongs to. 