### PR TITLE
Use JsonWebKey directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of nens-auth-client
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed deprecation warning by using JsonWebKey directly instead of calling
+  jwk.loads.
 
 
 1.2 (2023-03-20)

--- a/nens_auth_client/cognito.py
+++ b/nens_auth_client/cognito.py
@@ -1,5 +1,5 @@
 from authlib.integrations.django_client import DjangoOAuth2App
-from authlib.jose import JsonWebToken
+from authlib.jose import JsonWebKey, JsonWebToken
 from django.conf import settings
 from django.http.response import HttpResponseRedirect
 from urllib.parse import urlencode
@@ -119,11 +119,11 @@ class CognitoOAuthClient(DjangoOAuth2App):
             jwk_set = self.fetch_jwk_set()
             kid = header.get("kid")
             try:
-                return JsonWebToken.import_key_set(jwk_set).find_by_kid(kid)
+                return JsonWebKey.import_key_set(jwk_set).find_by_kid(kid)
             except ValueError:
                 # re-try with new jwk set
                 jwk_set = self.fetch_jwk_set(force=True)
-                return JsonWebToken.import_key_set(jwk_set).find_by_kid(kid)
+                return JsonWebKey.import_key_set(jwk_set).find_by_kid(kid)
 
         metadata = self.load_server_metadata()
         claims_options = {

--- a/nens_auth_client/cognito.py
+++ b/nens_auth_client/cognito.py
@@ -118,12 +118,13 @@ class CognitoOAuthClient(DjangoOAuth2App):
         # this is a copy from the _parse_id_token equivalent function
         def load_key(header, payload):
             jwk_set = self.fetch_jwk_set()
+            kid = header.get("kid")
             try:
-                return jwk.loads(jwk_set, header.get("kid"))
+                return JsonWebToken.import_key_set(jwk_set).find_by_kid(kid)
             except ValueError:
                 # re-try with new jwk set
                 jwk_set = self.fetch_jwk_set(force=True)
-                return jwk.loads(jwk_set, header.get("kid"))
+                return JsonWebToken.import_key_set(jwk_set).find_by_kid(kid)
 
         metadata = self.load_server_metadata()
         claims_options = {

--- a/nens_auth_client/cognito.py
+++ b/nens_auth_client/cognito.py
@@ -1,6 +1,5 @@
 from authlib.integrations.django_client import DjangoOAuth2App
 from authlib.jose import JsonWebToken
-from authlib.jose import jwk
 from django.conf import settings
 from django.http.response import HttpResponseRedirect
 from urllib.parse import urlencode

--- a/nens_auth_client/cognito.py
+++ b/nens_auth_client/cognito.py
@@ -1,5 +1,6 @@
 from authlib.integrations.django_client import DjangoOAuth2App
-from authlib.jose import JsonWebKey, JsonWebToken
+from authlib.jose import JsonWebKey
+from authlib.jose import JsonWebToken
 from django.conf import settings
 from django.http.response import HttpResponseRedirect
 from urllib.parse import urlencode


### PR DESCRIPTION
This deprecation warning shows up a lot in Lizard log files:
```
/srv/nxt.lizard.net/.venv/lib/python3.8/site-packages/authlib/jose/jwk.py:6: AuthlibDeprecationWarning: Please use ``JsonWebKey`` directly.
  deprecate('Please use ``JsonWebKey`` directly.')
```
Note that I did not exactly implement jwk.dumps, because I believe we should always find_by_kid: https://github.com/lepture/authlib/blob/master/authlib/jose/jwk.py