### PR TITLE
Check status of invitation up front

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of nens-auth-client
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Start the "accept invitation" workflow by checking the status of the
+  invitation - it should be PENDING.
 
 
 1.6.1 (2024-09-23)

--- a/nens_auth_client/tests/test_authorize_view.py
+++ b/nens_auth_client/tests/test_authorize_view.py
@@ -6,9 +6,11 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
+from importlib.metadata import version
 from nens_auth_client import models
 from nens_auth_client import views
 from nens_auth_client.views import LOGIN_REDIRECT_SESSION_KEY
+from packaging.version import Version
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
@@ -358,6 +360,10 @@ def test_authorize_bad_signature(id_token_generator, auth_req_generator):
         views.authorize(request)
 
 
+@pytest.mark.skipif(
+    Version(version("authlib")) > Version("1.6.6"),
+    reason="none algorithm is deprecated",
+)
 def test_authorize_unsigned_token(id_token_generator, auth_req_generator):
     # The id token has no signature
     id_token, claims = id_token_generator(alg="none")

--- a/nens_auth_client/tests/test_invitation_view.py
+++ b/nens_auth_client/tests/test_invitation_view.py
@@ -42,7 +42,9 @@ def test_invitation_accept(rf, get_object_or_404, invitation, invited_user):
     assert response.status_code == 302
     assert response.url == "/success/"
 
-    get_object_or_404.assert_called_with(Invitation, slug="foo")
+    get_object_or_404.assert_called_with(
+        Invitation, slug="foo", status=Invitation.PENDING
+    )
     invitation.accept.assert_called_with(request.user)
 
 
@@ -67,7 +69,9 @@ def test_invitation_does_not_exist(rf, get_object_or_404):
     with pytest.raises(Http404):
         views.accept_invitation(request, "foo")
 
-    get_object_or_404.assert_called_with(Invitation, slug="foo")
+    get_object_or_404.assert_called_with(
+        Invitation, slug="foo", status=Invitation.PENDING
+    )
 
 
 def test_invitation_expired(rf, get_object_or_404, invitation, invited_user):
@@ -80,7 +84,9 @@ def test_invitation_expired(rf, get_object_or_404, invitation, invited_user):
     with pytest.raises(PermissionDenied, match=".*has expired.*"):
         views.accept_invitation(request, "foo")
 
-    get_object_or_404.assert_called_with(Invitation, slug="foo")
+    get_object_or_404.assert_called_with(
+        Invitation, slug="foo", status=Invitation.PENDING
+    )
 
 
 def test_invitation_expired_anonymous_user(rf, get_object_or_404, invitation):
@@ -104,7 +110,9 @@ def test_invitation_used(rf, get_object_or_404, invitation, invited_user):
     with pytest.raises(PermissionDenied, match=".*has been used already.*"):
         views.accept_invitation(request, "foo")
 
-    get_object_or_404.assert_called_with(Invitation, slug="foo")
+    get_object_or_404.assert_called_with(
+        Invitation, slug="foo", status=Invitation.PENDING
+    )
     assert not invitation.accept.called
 
 
@@ -132,4 +140,6 @@ def test_invitation_not_logged_in(rf, get_object_or_404, invitation):
     assert query_parsed["invitation"] == ["foo"]
     assert query_parsed["next"] == ["/some/url/"]
 
-    get_object_or_404.assert_called_with(Invitation, slug="foo")
+    get_object_or_404.assert_called_with(
+        Invitation, slug="foo", status=Invitation.PENDING
+    )

--- a/nens_auth_client/tests/test_oauth.py
+++ b/nens_auth_client/tests/test_oauth.py
@@ -1,5 +1,7 @@
 from authlib.jose.errors import JoseError
+from importlib.metadata import version
 from nens_auth_client.oauth import get_oauth_client
+from packaging.version import Version
 
 import pytest
 import time
@@ -36,6 +38,10 @@ def test_parse_token_bad_signature(access_token_generator, jwks_request):
         get_oauth_client().parse_access_token(token)
 
 
+@pytest.mark.skipif(
+    Version(version("authlib")) > Version("1.6.6"),
+    reason="none algorithm is deprecated",
+)
 def test_parse_token_unsigned_token(access_token_generator, jwks_request):
     token = access_token_generator(alg="none")
     with pytest.raises(JoseError):

--- a/nens_auth_client/views.py
+++ b/nens_auth_client/views.py
@@ -290,7 +290,7 @@ def accept_invitation(request, slug):
     The full flow is described in the README.
     """
     # First check if the invitation is there and if it is still acceptable
-    invitation = get_object_or_404(Invitation, slug=slug)
+    invitation = get_object_or_404(Invitation, slug=slug, status=Invitation.PENDING)
 
     # We need a user - redirect to login view if user is not authenticated.
     # The acceptability of the invitation is checked in the login view.


### PR DESCRIPTION
I believe the current invitation workflow is correct in that you cannot reuse an invitation, but the check is rather late (upon entering you verification code). It seems more natural to check up front whether the status is PENDING. Perhaps more could be checked, e.g. if the invitation hasn't expired?